### PR TITLE
Hacky data structure for regular spacing

### DIFF
--- a/src/TemporalGPs.jl
+++ b/src/TemporalGPs.jl
@@ -8,13 +8,14 @@ module TemporalGPs
 
     import Stheno: mean, cov, pairwise, logpdf, AV, AM
 
-    export to_sde, SArrayStorage, ArrayStorage
+    export to_sde, SArrayStorage, ArrayStorage, RegularSpacing
 
     # Various bits-and-bobs. Often commiting some type piracy.
     include(joinpath("util", "zygote_rules.jl"))
     include(joinpath("util", "gaussian.jl"))
     include(joinpath("util", "mul.jl"))
     include(joinpath("util", "storage_types.jl"))
+    include(joinpath("util", "regular_data.jl"))
 
     # Linear-Gaussian State Space Models.
     include(joinpath("models", "gauss_markov.jl"))

--- a/src/gp/to_gauss_markov.jl
+++ b/src/gp/to_gauss_markov.jl
@@ -30,7 +30,7 @@ end
 
 function GaussMarkovModel(
     k::BaseKernel,
-    t::StepRangeLen,
+    t::Union{StepRangeLen, RegularSpacing},
     storage_type::StorageType{T},
 ) where {T<:Real}
 

--- a/src/util/regular_data.jl
+++ b/src/util/regular_data.jl
@@ -17,3 +17,16 @@ Base.IndexStyle(::RegularSpacing) = Base.IndexLinear()
 Base.size(x::RegularSpacing) = (x.N,)
 
 Base.getindex(x::RegularSpacing, n::Int) = x.t0 + (n - 1) * x.Δt
+
+Base.step(x::RegularSpacing) = x.Δt
+
+ZygoteRules.@adjoint function (::Type{TR})(t0::T, Δt::T, N::Int) where {TR<:RegularSpacing, T<:Real}
+    function pullback_RegularSpacing(Δ::TΔ) where {TΔ<:NamedTuple}
+        return (
+            hasfield(TΔ, :t0) ? Δ.t0 : nothing,
+            hasfield(TΔ, :Δt) ? Δ.Δt : nothing,
+            nothing,
+        )
+    end
+    return RegularSpacing(t0, Δt, N), pullback_RegularSpacing
+end

--- a/src/util/regular_data.jl
+++ b/src/util/regular_data.jl
@@ -1,0 +1,19 @@
+"""
+    RegularSpacing{T<:Real} <: AbstractVector{T}
+
+Equivalent to `range(t0; step=Δt, length=N)`, but possible to differentiate through. This
+will be removed once it's possible to differentiate through `range`s using `Zygote`.
+"""
+struct RegularSpacing{T<:Real} <: AbstractVector{T}
+    t0::T
+    Δt::T
+    N::Int
+end
+
+# Implements the AbstractArray interface.
+
+Base.IndexStyle(::RegularSpacing) = Base.IndexLinear()
+
+Base.size(x::RegularSpacing) = (x.N,)
+
+Base.getindex(x::RegularSpacing, n::Int) = x.t0 + (n - 1) * x.Δt

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ include("test_util.jl")
         include(joinpath("util", "zygote_rules.jl"))
         include(joinpath("util", "gaussian.jl"))
         include(joinpath("util", "mul.jl"))
+        include(joinpath("util", "regular_data.jl"))
     end
 
     include(joinpath("models", "model_test_utils.jl"))

--- a/test/util/regular_data.jl
+++ b/test/util/regular_data.jl
@@ -1,3 +1,10 @@
+function FiniteDifferences.to_vec(x::RegularSpacing)
+    function from_vec_RegularSpacing(x_vec)
+        return RegularSpacing(x[1], x[2], x.N)
+    end
+    return [x.t0, x.Δt], from_vec_RegularSpacing
+end
+
 @testset "regular_data" begin
     t0 = randn()
     Δt = randn()
@@ -8,6 +15,8 @@
     @test size(x) == size(x_range)
     @test getindex(x, 3) ≈ getindex(x_range, 3)
     @test collect(x) ≈ collect(x_range)
+    @test step(x) == step(x_range)
+    @test length(x) == length(x_range)
 
     let
         x, back = Zygote.pullback(RegularSpacing, t0, Δt, N)
@@ -15,5 +24,11 @@
         Δ_t0 = randn()
         Δ_Δt = randn()
         @test back((t0 = Δ_t0, Δt = Δ_Δt, N=nothing)) == (Δ_t0, Δ_Δt, nothing)
+
+        adjoint_test(
+            (t0, Δt) -> RegularSpacing(t0, Δt, 5),
+            (t0 = randn(), Δt = randn()),
+            randn(), randn(),
+        )
     end
 end

--- a/test/util/regular_data.jl
+++ b/test/util/regular_data.jl
@@ -1,0 +1,19 @@
+@testset "regular_data" begin
+    t0 = randn()
+    Δt = randn()
+    N = 5
+    x = RegularSpacing(t0, Δt, N)
+    x_range = range(t0; step=Δt, length=N)
+
+    @test size(x) == size(x_range)
+    @test getindex(x, 3) ≈ getindex(x_range, 3)
+    @test collect(x) ≈ collect(x_range)
+
+    let
+        x, back = Zygote.pullback(RegularSpacing, t0, Δt, N)
+
+        Δ_t0 = randn()
+        Δ_Δt = randn()
+        @test back((t0 = Δ_t0, Δt = Δ_Δt, N=nothing)) == (Δ_t0, Δ_Δt, nothing)
+    end
+end


### PR DESCRIPTION
Annoyingly, Zygote doesn't play nicely with `range` et al. This PR introduces a range-like data structure that does. Ideally it will be removed from the code base before too long.