### PR TITLE
Remove Mutable / Immutable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TemporalGPs"
 uuid = "e155a3c4-0841-43e1-8b83-a0e4f03cc18f"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk>"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/models/checkpointed_immutable_pullbacks.jl
+++ b/src/models/checkpointed_immutable_pullbacks.jl
@@ -46,17 +46,15 @@ for (foo, step_foo, foo_pullback, step_foo_pullback) in [
     (:decorrelate, :step_decorrelate, :decorrelate_pullback, :step_decorrelate_pullback),
 ]
     @eval @adjoint function $foo(
-        ::Immutable,
         model::CheckpointedLGSSM,
         ys::AV{<:AV{<:Real}},
         f=copy_first,
     )
-        return $foo_pullback(Immutable(), model, ys, f)
+        return $foo_pullback(model, ys, f)
     end
 
     # Standard rrule a la ZygoteRules.
     @eval function $foo_pullback(
-        ::Immutable,
         model_checkpointed::CheckpointedLGSSM{V},
         ys::AV{<:AV{<:Real}},
         f,

--- a/src/models/checkpointed_immutable_pullbacks.jl
+++ b/src/models/checkpointed_immutable_pullbacks.jl
@@ -29,36 +29,30 @@ mean(model::CheckpointedLGSSM) = mean(model.model)
 
 cov(model::CheckpointedLGSSM) = cov(model.model)
 
-function decorrelate(mut, model::CheckpointedLGSSM, ys::AV{<:AV{<:Real}}, f=copy_first)
-    return decorrelate(mut, model.model, ys, f)
+function decorrelate(model::CheckpointedLGSSM, ys::AV{<:AV{<:Real}}, f)
+    return decorrelate(model.model, ys, f)
 end
 
-function correlate(mut, model::CheckpointedLGSSM, ys::AV{<:AV{<:Real}}, f=copy_first)
-    return correlate(mut, model.model, ys, f)
+function correlate(model::CheckpointedLGSSM, ys::AV{<:AV{<:Real}}, f)
+    return correlate(model.model, ys, f)
 end
 
 #
 # Checkpointed pullbacks.
 #
 
-for (foo, step_foo, foo_pullback, step_foo_pullback) in [
-    (:correlate, :step_correlate, :correlate_pullback, :step_correlate_pullback),
-    (:decorrelate, :step_decorrelate, :decorrelate_pullback, :step_decorrelate_pullback),
+for (foo, step_foo, foo_pullback) in [
+    (:correlate, :step_correlate, :correlate_pullback),
+    (:decorrelate, :step_decorrelate, :decorrelate_pullback),
 ]
-    @eval @adjoint function $foo(
-        model::CheckpointedLGSSM,
-        ys::AV{<:AV{<:Real}},
-        f=copy_first,
-    )
+    @eval @adjoint function $foo(model::CheckpointedLGSSM, ys::AV{<:AV{<:Real}}, f)
         return $foo_pullback(model, ys, f)
     end
 
     # Standard rrule a la ZygoteRules.
     @eval function $foo_pullback(
-        model_checkpointed::CheckpointedLGSSM{V},
-        ys::AV{<:AV{<:Real}},
-        f,
-    ) where {V}
+        model_checkpointed::CheckpointedLGSSM, ys::AV{<:AV{<:Real}}, f,
+    )
         model = model_checkpointed.model
         @assert length(model) == length(ys)
         T = length(model)
@@ -83,8 +77,6 @@ for (foo, step_foo, foo_pullback, step_foo_pullback) in [
 
         # Run first block to obtain type
         lml = 0.0
-        # x = x0
-        # x = model.gmm.x0
         for b in 1:B
             for c in 1:min(B, T - (b - 1) * B)
                 t = (b - 1) * B + c
@@ -105,14 +97,10 @@ for (foo, step_foo, foo_pullback, step_foo_pullback) in [
             xs_block[1] = xs_block[end]
         end
 
-        function foo_pullback(Δ::Tuple{Any, Nothing})
-            return foo_pullback((first(Δ), Fill(nothing, T)))
-        end
-
-        function foo_pullback(Δ::Tuple{Any, AbstractVector})
+        function foo_pullback(Δ::Tuple{Any, Union{Nothing, AbstractVector}})
 
             Δlml = Δ[1]
-            Δvs = Δ[2]
+            Δvs = Δ[2] isa Nothing ? Fill(nothing, T) : Δ[2]
 
             # Compute the pullback through the last element of the chain to get
             # initialisations for cotangents to accumulate.
@@ -158,7 +146,7 @@ for (foo, step_foo, foo_pullback, step_foo_pullback) in [
                 Σ = Δmodel.Σ,
             )
 
-            return nothing, (model = Δmodel_, ), Δys, nothing
+            return (model = Δmodel_, ), Δys, nothing
         end
 
         return (lml, vs), foo_pullback

--- a/src/models/checkpointed_immutable_pullbacks.jl
+++ b/src/models/checkpointed_immutable_pullbacks.jl
@@ -45,12 +45,12 @@ for (foo, step_foo, foo_pullback) in [
     (:correlate, :step_correlate, :correlate_pullback),
     (:decorrelate, :step_decorrelate, :decorrelate_pullback),
 ]
-    @eval @adjoint function $foo(model::CheckpointedLGSSM, ys::AV{<:AV{<:Real}}, f)
-        return $foo_pullback(model, ys, f)
-    end
+    # @eval @adjoint function $foo(model::CheckpointedLGSSM, ys::AV{<:AV{<:Real}}, f)
+    #     return $foo_pullback(model, ys, f)
+    # end
 
     # Standard rrule a la ZygoteRules.
-    @eval function $foo_pullback(
+    @eval @adjoint function $foo(
         model_checkpointed::CheckpointedLGSSM, ys::AV{<:AV{<:Real}}, f,
     )
         model = model_checkpointed.model
@@ -97,7 +97,7 @@ for (foo, step_foo, foo_pullback) in [
             xs_block[1] = xs_block[end]
         end
 
-        function foo_pullback(Δ::Tuple{Any, Union{Nothing, AbstractVector}})
+        function $foo_pullback(Δ::Tuple{Any, Union{Nothing, AbstractVector}})
 
             Δlml = Δ[1]
             Δvs = Δ[2] isa Nothing ? Fill(nothing, T) : Δ[2]
@@ -149,7 +149,7 @@ for (foo, step_foo, foo_pullback) in [
             return (model = Δmodel_, ), Δys, nothing
         end
 
-        return (lml, vs), foo_pullback
+        return (lml, vs), $foo_pullback
     end
 end
 

--- a/src/models/immutable_inference.jl
+++ b/src/models/immutable_inference.jl
@@ -6,7 +6,7 @@ copy_first(a, b) = copy(a)
 
 pick_last(a, b) = b
 
-function decorrelate(::Immutable, model::LGSSM, ys::AV{<:AV{<:Real}}, f=copy_first)
+function decorrelate(model::LGSSM, ys::AV{<:AV{<:Real}}, f=copy_first)
     @assert length(model) == length(ys)
 
     # Process first latent.
@@ -24,7 +24,7 @@ function decorrelate(::Immutable, model::LGSSM, ys::AV{<:AV{<:Real}}, f=copy_fir
     return lml, vs
 end
 
-function correlate(::Immutable, model::LGSSM, αs::AV{<:AV{<:Real}}, f=copy_first)
+function correlate(model::LGSSM, αs::AV{<:AV{<:Real}}, f=copy_first)
     @assert length(model) == length(αs)
 
     # Process first latent.

--- a/src/models/immutable_inference.jl
+++ b/src/models/immutable_inference.jl
@@ -6,7 +6,7 @@ copy_first(a, b) = copy(a)
 
 pick_last(a, b) = b
 
-function decorrelate(model::LGSSM, ys::AV{<:AV{<:Real}}, f=copy_first)
+function decorrelate(model::LGSSM, ys::AV{<:AV{<:Real}}, f)
     @assert length(model) == length(ys)
 
     # Process first latent.
@@ -24,7 +24,7 @@ function decorrelate(model::LGSSM, ys::AV{<:AV{<:Real}}, f=copy_first)
     return lml, vs
 end
 
-function correlate(model::LGSSM, αs::AV{<:AV{<:Real}}, f=copy_first)
+function correlate(model::LGSSM, αs::AV{<:AV{<:Real}}, f)
     @assert length(model) == length(αs)
 
     # Process first latent.

--- a/src/models/immutable_inference_pullbacks.jl
+++ b/src/models/immutable_inference_pullbacks.jl
@@ -76,7 +76,7 @@ for (foo, step_foo, foo_pullback) in [
     (:correlate, :step_correlate, :correlate_pullback),
     (:decorrelate, :step_decorrelate, :decorrelate_pullback),
 ]
-    @eval @adjoint function $foo(model::LGSSM, ys::AV{<:AV{<:Real}}, f=copy_first)
+    @eval @adjoint function $foo(model::LGSSM, ys::AV{<:AV{<:Real}}, f)
         return $foo_pullback(model, ys, f)
     end
 
@@ -106,10 +106,6 @@ for (foo, step_foo, foo_pullback) in [
             lml += lml_
             vs[t] = f(α, x)
         end
-
-        # function foo_pullback(Δ::Tuple{Any, Nothing})
-        #     return foo_pullback((Δ[1], Fill(nothing, T)))
-        # end
 
         function foo_pullback(Δ::Tuple{Any, Union{AbstractVector, Nothing}})
 
@@ -141,7 +137,7 @@ for (foo, step_foo, foo_pullback) in [
                 Σ = Δmodel.Σ,
             )
 
-            return nothing, Δmodel_, Δys, nothing
+            return Δmodel_, Δys, nothing
         end
 
         return (lml, vs), foo_pullback

--- a/src/models/immutable_inference_pullbacks.jl
+++ b/src/models/immutable_inference_pullbacks.jl
@@ -76,17 +76,12 @@ for (foo, step_foo, foo_pullback) in [
     (:correlate, :step_correlate, :correlate_pullback),
     (:decorrelate, :step_decorrelate, :decorrelate_pullback),
 ]
-    @eval @adjoint function $foo(
-        ::Immutable,
-        model::LGSSM,
-        ys::AV{<:AV{<:Real}},
-        f=copy_first,
-    )
-        return $foo_pullback(Immutable(), model, ys, f)
+    @eval @adjoint function $foo(model::LGSSM, ys::AV{<:AV{<:Real}}, f=copy_first)
+        return $foo_pullback(model, ys, f)
     end
 
     # Standard rrule a la ChainRulesCore.
-    @eval function $foo_pullback(::Immutable, model::LGSSM, ys::AV{<:AV{<:Real}}, f)
+    @eval function $foo_pullback(model::LGSSM, ys::AV{<:AV{<:Real}}, f)
         @assert length(model) == length(ys)
         T = length(model)
 

--- a/src/models/immutable_inference_pullbacks.jl
+++ b/src/models/immutable_inference_pullbacks.jl
@@ -76,12 +76,12 @@ for (foo, step_foo, foo_pullback) in [
     (:correlate, :step_correlate, :correlate_pullback),
     (:decorrelate, :step_decorrelate, :decorrelate_pullback),
 ]
-    @eval @adjoint function $foo(model::LGSSM, ys::AV{<:AV{<:Real}}, f)
-        return $foo_pullback(model, ys, f)
-    end
+    # @eval @adjoint function $foo(model::LGSSM, ys::AV{<:AV{<:Real}}, f)
+    #     return $foo_pullback(model, ys, f)
+    # end
 
     # Standard rrule a la ChainRulesCore.
-    @eval function $foo_pullback(model::LGSSM, ys::AV{<:AV{<:Real}}, f)
+    @eval @adjoint function $foo(model::LGSSM, ys::AV{<:AV{<:Real}}, f)
         @assert length(model) == length(ys)
         T = length(model)
 
@@ -107,7 +107,7 @@ for (foo, step_foo, foo_pullback) in [
             vs[t] = f(α, x)
         end
 
-        function foo_pullback(Δ::Tuple{Any, Union{AbstractVector, Nothing}})
+        function $foo_pullback(Δ::Tuple{Any, Union{AbstractVector, Nothing}})
 
             Δlml = Δ[1]
             Δvs = Δ[2] isa Nothing ? Fill(nothing, T) : Δ[2]
@@ -140,6 +140,6 @@ for (foo, step_foo, foo_pullback) in [
             return Δmodel_, Δys, nothing
         end
 
-        return (lml, vs), foo_pullback
+        return (lml, vs), $foo_pullback
     end
 end

--- a/src/models/lgssm.jl
+++ b/src/models/lgssm.jl
@@ -156,13 +156,8 @@ end
 # This dispatch to methods specialised to the array type used to represent the LGSSM.
 #
 
-function decorrelate(model::AbstractSSM, ys::AbstractVector, f=copy_first)
-    return decorrelate(mutability(storage_type(model)), model, ys, f)
-end
-
-function correlate(model::AbstractSSM, αs::AbstractVector, f=copy_first)
-    return correlate(mutability(storage_type(model)), model, αs, f)
-end
+decorrelate(model::AbstractSSM, y::AbstractVector) = decorrelate(model, y, copy_first)
+correlate(model::AbstractSSM, y::AbstractVector) = correlate(model, y, copy_first)
 
 
 

--- a/src/models/scalar_lgssm.jl
+++ b/src/models/scalar_lgssm.jl
@@ -53,13 +53,9 @@ function correlate(model::ScalarLGSSM, αs::AbstractVector{<:Real}, f=copy_first
 end
 
 function decorrelate(model::ScalarLGSSM, ys::AbstractVector{<:Real}, f=copy_first)
-    return decorrelate(mutability(storage_type(model)), model, ys, f)
-end
-
-function decorrelate(mut, model::ScalarLGSSM, ys::AbstractVector{<:Real}, f=copy_first)
     storage = storage_type(model)
     ys_vec = to_vector_observations(storage, ys)
-    lml, αs = decorrelate(mut, model.model, ys_vec, f)
+    lml, αs = decorrelate(model.model, ys_vec, f)
     return lml, from_vector_observations(αs)
 end
 

--- a/src/util/storage_types.jl
+++ b/src/util/storage_types.jl
@@ -26,8 +26,6 @@ struct SArrayStorage{T<:Real} <: StorageType{T} end
 
 SArrayStorage(T) = SArrayStorage{T}()
 
-mutability(::SArrayStorage) = Immutable()
-
 is_of_storage_type(::SArray{<:Any, T}, ::SArrayStorage{T}) where {T<:Real} = true
 
 
@@ -40,18 +38,4 @@ struct ArrayStorage{T<:Real} <: StorageType{T} end
 
 ArrayStorage(T) = ArrayStorage{T}()
 
-mutability(::ArrayStorage) = Immutable()
-
 is_of_storage_type(::Array{T}, ::ArrayStorage{T}) where {T<:Real} = true
-
-
-
-#
-# Is an array type to be considered Mutable or Immutable by this package?
-#
-
-struct Mutable end
-
-struct Immutable end
-
-Zygote.@nograd mutability

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -8,6 +8,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Stheno = "8188c328-b5d6-583d-959b-9690869a5511"
+TemporalGPs = "e155a3c4-0841-43e1-8b83-a0e4f03cc18f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 

--- a/test/models/checkpointed_immutable_pullbacks.jl
+++ b/test/models/checkpointed_immutable_pullbacks.jl
@@ -1,5 +1,4 @@
 using TemporalGPs:
-    Immutable,
     correlate,
     decorrelate,
     correlate_pullback,
@@ -29,11 +28,10 @@ using TemporalGPs:
     ]
 
         # Perform filtering / gradient propagation with no checkpointing.
-        (lml_naive, ys_naive), pb_naive = foo_pullback(Immutable(), model, α, copy_first)
+        (lml_naive, ys_naive), pb_naive = foo_pullback(model, α, copy_first)
 
         # Perform filtering / gradient propagation with checkpointing.
         (lml_checkpoint, ys_checkpoint), pb_checkpoint = foo_pullback(
-            Immutable(),
             model_checkpointed,
             α,
             copy_first,

--- a/test/models/checkpointed_immutable_pullbacks.jl
+++ b/test/models/checkpointed_immutable_pullbacks.jl
@@ -32,9 +32,7 @@ using TemporalGPs:
 
         # Perform filtering / gradient propagation with checkpointing.
         (lml_checkpoint, ys_checkpoint), pb_checkpoint = foo_pullback(
-            model_checkpointed,
-            α,
-            copy_first,
+            model_checkpointed, α, copy_first,
         )
 
         @test lml_naive ≈ lml_checkpoint
@@ -43,8 +41,8 @@ using TemporalGPs:
         Δlml = randn()
         Δys = [randn(Dobs) for _ in 1:N]
 
-        _, Δmodel_naive, Δαs_naive, _ = pb_naive((Δlml, Δys))
-        _, Δmodel_checkpoint, Δαs_checkpoint = pb_checkpoint((Δlml, Δys))
+        Δmodel_naive, Δαs_naive, _ = pb_naive((Δlml, Δys))
+        Δmodel_checkpoint, Δαs_checkpoint = pb_checkpoint((Δlml, Δys))
 
         @test Δmodel_naive == Δmodel_checkpoint.model
         @test Δαs_naive == Δαs_checkpoint

--- a/test/models/checkpointed_immutable_pullbacks.jl
+++ b/test/models/checkpointed_immutable_pullbacks.jl
@@ -1,8 +1,6 @@
 using TemporalGPs:
     correlate,
     decorrelate,
-    correlate_pullback,
-    decorrelate_pullback,
     copy_first,
     smooth
 
@@ -22,17 +20,17 @@ using TemporalGPs:
     y = rand(model)
     _, α = TemporalGPs.decorrelate(model, y)
 
-    @testset "$(name)" for (name, foo_pullback) in [
-        ("correlate", correlate_pullback),
-        ("decorrelate", decorrelate_pullback),
+    @testset "$(name)" for (name, foo) in [
+        ("correlate", correlate),
+        ("decorrelate", decorrelate),
     ]
 
         # Perform filtering / gradient propagation with no checkpointing.
-        (lml_naive, ys_naive), pb_naive = foo_pullback(model, α, copy_first)
+        (lml_naive, ys_naive), pb_naive = Zygote.pullback(foo, model, α, copy_first)
 
         # Perform filtering / gradient propagation with checkpointing.
-        (lml_checkpoint, ys_checkpoint), pb_checkpoint = foo_pullback(
-            model_checkpointed, α, copy_first,
+        (lml_checkpoint, ys_checkpoint), pb_checkpoint = Zygote.pullback(
+            foo, model_checkpointed, α, copy_first,
         )
 
         @test lml_naive ≈ lml_checkpoint

--- a/test/models/immutable_inference.jl
+++ b/test/models/immutable_inference.jl
@@ -143,7 +143,7 @@ println("immutable inference:")
             end
 
             @testset "$name infers" begin
-                _, pb = _pullback(NoContext(), f, gssm, ys)
+                _, pb = _pullback(NoContext(), f, lgssm, ys)
                 @inferred f(lgssm, ys, copy_first)
                 @inferred _pullback(NoContext(), f, lgssm, ys, copy_first)
                 @inferred pb((randn(), αs))

--- a/test/models/immutable_inference.jl
+++ b/test/models/immutable_inference.jl
@@ -7,7 +7,6 @@ using TemporalGPs:
     step_correlate,
     decorrelate,
     correlate,
-    Immutable,
     copy_first
 using Zygote: _pullback
 
@@ -144,9 +143,9 @@ println("immutable inference:")
             end
 
             @testset "$name infers" begin
-                _, pb = _pullback(NoContext(), f, Immutable(), lgssm, ys)
-                @inferred f(Immutable(), lgssm, ys, copy_first)
-                @inferred _pullback(NoContext(), f, Immutable(), lgssm, ys, copy_first)
+                _, pb = _pullback(NoContext(), f, gssm, ys)
+                @inferred f(lgssm, ys, copy_first)
+                @inferred _pullback(NoContext(), f, lgssm, ys, copy_first)
                 @inferred pb((randn(), αs))
             end
 
@@ -154,17 +153,14 @@ println("immutable inference:")
             # possible that they'll need to be modified in future / for different versions
             # of Julia.
             @testset "$name allocations are independent of length" begin
-                _, pb = _pullback(NoContext(), f, Immutable(), lgssm, ys, copy_first)
+                _, pb = _pullback(NoContext(), f, lgssm, ys, copy_first)
 
                 @test allocs(
-                    @benchmark(
-                        $f(Immutable(), $lgssm, $ys, copy_first);
-                        samples=1, evals=1,
-                    ),
+                    @benchmark($f($lgssm, $ys, copy_first); samples=1, evals=1),
                 ) < 5
                 @test allocs(
                     @benchmark(
-                        _pullback(NoContext(), $f, Immutable(), $lgssm, $ys, copy_first);
+                        _pullback(NoContext(), $f, $lgssm, $ys, copy_first);
                         samples=1, evals=1,
                     ),
                 ) < 10
@@ -173,12 +169,12 @@ println("immutable inference:")
 
             # @testset "benchmarking $name" begin
             #     @show Dlat, Dobs, name, T.T
-            #     _, pb = _pullback(NoContext(), f, Immutable(), lgssm, ys, copy_first)
+            #     _, pb = _pullback(NoContext(), f, lgssm, ys, copy_first)
 
-            #     display(@benchmark($f(Immutable(), $lgssm, $ys, copy_first)))
+            #     display(@benchmark($f($lgssm, $ys, copy_first)))
             #     println()
             #     display(@benchmark(
-            #         _pullback(NoContext(), $f, Immutable(), $lgssm, $ys, copy_first),
+            #         _pullback(NoContext(), $f, $lgssm, $ys, copy_first),
             #     ))
             #     println()
             #     display(@benchmark($pb((randn(), $αs))))


### PR DESCRIPTION
These should have been removed in #36 but unfortunately that didn't happen. They weren't user-facing, so the change isn't breaking.

edit: also remove `decorrelate_pullback` and `correlate_pullback` functions, as they were redundant. Instead, there are now just the appropriate `Zygote._pullback` methods.